### PR TITLE
[dependencies] Require NCCL 2.31.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ classifiers = [
 dependencies = [
     "jax[cuda13]>=0.8.0,<=0.11.0",
     "nccl4py[cu13]>=0.3.1,<0.4",
+    "nvidia-nccl-cu13>=2.31.2",
     "cuda.core>=1.0,<2.0",
     "cuda-bindings>=13.0,<14.0",
 ]


### PR DESCRIPTION
Require NCCL 2.31.2 for CUDA 13 installations. Fixes #11 


